### PR TITLE
Fixed UI stalling in 500 Error Page

### DIFF
--- a/F1StrategySite/Components/Pages/Errors/Error.razor
+++ b/F1StrategySite/Components/Pages/Errors/Error.razor
@@ -9,7 +9,9 @@
     {
         var uri = NavManager.ToAbsoluteUri(NavManager.Uri);
         var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-        if (int.TryParse(query["StatusCode"], out var code))
+        // Support both "StatusCode" (used by internal redirects) and "code" (used by UseStatusCodePagesWithReExecute)
+        var statusFromQuery = query["StatusCode"] ?? query["code"];
+        if (int.TryParse(statusFromQuery, out var code))
         {
             StatusCode = code;
         }

--- a/F1StrategySite/Components/Routes.razor
+++ b/F1StrategySite/Components/Routes.razor
@@ -2,12 +2,23 @@
 
 <Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
-        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+        <ErrorBoundary @key="routeData.PageType">
+            <ChildContent>
+                <RouteView RouteData="routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
+                <FocusOnNavigate RouteData="routeData" Selector="h1" />
+            </ChildContent>
+            <ErrorContent>
+                <!-- Render error content directly to ensure SSR shows UI without relying on client-side redirects -->
+                <LayoutView Layout="@typeof(Layout.MainLayout)">
+                    <Error StatusCode="500" />
+                </LayoutView>
+            </ErrorContent>
+        </ErrorBoundary>
     </Found>
     <NotFound>
-        <LayoutView>
-            <RedirectTo To="/Error?StatusCode=404" />
+        <!-- Show 404 content directly (no redirect) so SSR displays immediately -->
+        <LayoutView Layout="@typeof(Layout.MainLayout)">
+            <Error StatusCode="404" />
         </LayoutView>
     </NotFound>
 </Router>

--- a/F1StrategySite/Program.cs
+++ b/F1StrategySite/Program.cs
@@ -10,7 +10,14 @@ builder.WebHost.UseStaticWebAssets();
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents();
+    .AddInteractiveServerComponents(options =>
+    {
+        // Surface detailed circuit errors to the browser when developing
+        if (builder.Environment.IsDevelopment())
+        {
+            options.DetailedErrors = true;
+        }
+    });
 builder.Services.AddControllers();
 builder.Services.AddRazorPages(options =>
 {

--- a/F1StrategySite/Properties/PublishProfiles/pitdatainsights - Zip Deploy.pubxml
+++ b/F1StrategySite/Properties/PublishProfiles/pitdatainsights - Zip Deploy.pubxml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project>
+  <PropertyGroup>
+    <WebPublishMethod>ZipDeploy</WebPublishMethod>
+    <IsLinux>true</IsLinux>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <ResourceId>/subscriptions/bfcce8df-ec93-43a0-9a3f-425cba9927f3/resourceGroups/web-strategy/providers/Microsoft.Web/sites/pitdatainsights</ResourceId>
+    <ResourceGroup>web-strategy</ResourceGroup>
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <SiteUrlToLaunchAfterPublish>https://pitdatainsights.azurewebsites.net</SiteUrlToLaunchAfterPublish>
+    <PublishProvider>AzureWebSite</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <ProjectGuid>1fd65086-64e9-4369-8944-2a1c8a318a12</ProjectGuid>
+    <PublishUrl>https://pitdatainsights.scm.azurewebsites.net/</PublishUrl>
+    <UserName />
+    <_SavePWD>false</_SavePWD>
+  </PropertyGroup>
+</Project>

--- a/F1StrategySite/Properties/ServiceDependencies/pitdatainsights - Zip Deploy/profile.arm.json
+++ b/F1StrategySite/Properties/ServiceDependencies/pitdatainsights - Zip Deploy/profile.arm.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_dependencyType": "compute.function.linux.appService"
+  },
+  "parameters": {
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "web-strategy",
+      "metadata": {
+        "description": "Name of the resource group for the resource. It is recommended to put resources under same resource group for better tracking."
+      }
+    },
+    "resourceGroupLocation": {
+      "type": "string",
+      "defaultValue": "polandcentral",
+      "metadata": {
+        "description": "Location of the resource group. Resource groups could have different location than resources, however by default we use API versions from latest hybrid profile which support all locations for resource types we support."
+      }
+    },
+    "resourceName": {
+      "type": "string",
+      "defaultValue": "pitdatainsights",
+      "metadata": {
+        "description": "Name of the main resource to be created by this template."
+      }
+    },
+    "resourceLocation": {
+      "type": "string",
+      "defaultValue": "[parameters('resourceGroupLocation')]",
+      "metadata": {
+        "description": "Location of the resource. By default use resource group's location, unless the resource provider is not supported there."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "name": "[parameters('resourceGroupName')]",
+      "location": "[parameters('resourceGroupLocation')]",
+      "apiVersion": "2019-10-01"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat(parameters('resourceGroupName'), 'Deployment', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+      "resourceGroup": "[parameters('resourceGroupName')]",
+      "apiVersion": "2019-10-01",
+      "dependsOn": [
+        "[parameters('resourceGroupName')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "parameters": {
+          "resourceGroupName": {
+            "value": "[parameters('resourceGroupName')]"
+          },
+          "resourceGroupLocation": {
+            "value": "[parameters('resourceGroupLocation')]"
+          },
+          "resourceName": {
+            "value": "[parameters('resourceName')]"
+          },
+          "resourceLocation": {
+            "value": "[parameters('resourceLocation')]"
+          }
+        },
+        "template": {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {
+            "resourceGroupName": {
+              "type": "string"
+            },
+            "resourceGroupLocation": {
+              "type": "string"
+            },
+            "resourceName": {
+              "type": "string"
+            },
+            "resourceLocation": {
+              "type": "string"
+            }
+          },
+          "variables": {
+            "storage_name": "[toLower(concat('storage', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId))))]",
+            "appServicePlan_name": "[concat('Plan', uniqueString(concat(parameters('resourceName'), subscription().subscriptionId)))]",
+            "storage_ResourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', variables('storage_name'))]",
+            "appServicePlan_ResourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Web/serverFarms/', variables('appServicePlan_name'))]",
+            "function_ResourceId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('resourceGroupName'), '/providers/Microsoft.Web/sites/', parameters('resourceName'))]"
+          },
+          "resources": [
+            {
+              "location": "[parameters('resourceLocation')]",
+              "name": "[parameters('resourceName')]",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "tags": {
+                "[concat('hidden-related:', variables('appServicePlan_ResourceId'))]": "empty"
+              },
+              "dependsOn": [
+                "[variables('appServicePlan_ResourceId')]",
+                "[variables('storage_ResourceId')]"
+              ],
+              "kind": "functionapp",
+              "properties": {
+                "name": "[parameters('resourceName')]",
+                "kind": "functionapp",
+                "httpsOnly": true,
+                "reserved": false,
+                "serverFarmId": "[variables('appServicePlan_ResourceId')]",
+                "siteConfig": {
+                  "alwaysOn": true,
+                  "linuxFxVersion": "dotnet|3.1"
+                }
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "resources": [
+                {
+                  "name": "appsettings",
+                  "type": "config",
+                  "apiVersion": "2015-08-01",
+                  "dependsOn": [
+                    "[variables('function_ResourceId')]"
+                  ],
+                  "properties": {
+                    "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storage_name'), ';AccountKey=', listKeys(variables('storage_ResourceId'), '2017-10-01').keys[0].value, ';EndpointSuffix=', 'core.windows.net')]",
+                    "FUNCTIONS_EXTENSION_VERSION": "~3",
+                    "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+                  }
+                }
+              ]
+            },
+            {
+              "location": "[parameters('resourceGroupLocation')]",
+              "name": "[variables('storage_name')]",
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2017-10-01",
+              "tags": {
+                "[concat('hidden-related:', concat('/providers/Microsoft.Web/sites/', parameters('resourceName')))]": "empty"
+              },
+              "properties": {
+                "supportsHttpsTrafficOnly": true
+              },
+              "sku": {
+                "name": "Standard_LRS"
+              },
+              "kind": "Storage"
+            },
+            {
+              "location": "[parameters('resourceGroupLocation')]",
+              "name": "[variables('appServicePlan_name')]",
+              "type": "Microsoft.Web/serverFarms",
+              "apiVersion": "2015-02-01",
+              "kind": "linux",
+              "properties": {
+                "name": "[variables('appServicePlan_name')]",
+                "sku": "Standard",
+                "workerSizeId": "0",
+                "reserved": true
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces improvements to error handling and deployment configuration for the site. The main changes enhance server-side rendering (SSR) of error pages, allow more robust error detection, and add Azure deployment profiles for streamlined publishing.

**Error handling and SSR improvements:**

* Updated the router in `Routes.razor` to render error pages directly for both general errors and 404s, ensuring SSR displays error UI immediately instead of relying on client-side redirects. Added an `ErrorBoundary` to catch and display errors with a consistent layout.
* Improved the error component in `Error.razor` to support both `"StatusCode"` and `"code"` query parameters, making error detection compatible with different redirect mechanisms.
* Enabled detailed circuit errors in development mode for interactive server components, making debugging easier.

**Deployment and Azure configuration:**

* Added a new Azure publish profile (`pitdatainsights - Zip Deploy.pubxml`) for zip deployment, specifying Linux runtime and resource details for streamlined publishing to Azure.
* Included an ARM template (`pitdatainsights - Zip Deploy/profile.arm.json`) describing Azure resources needed for deployment, including web app, storage, and app service plan.